### PR TITLE
Setting main grist-widget repository as a default

### DIFF
--- a/ext/app/electron/main.ts
+++ b/ext/app/electron/main.ts
@@ -28,6 +28,8 @@ setDefaultEnv('GRIST_ORG_IN_PATH', 'true');
 setDefaultEnv('APP_UNTRUSTED_URL', 'http://plugins.invalid');
 setDefaultEnv('GRIST_HIDE_UI_ELEMENTS', 'helpCenter,billing,templates,multiSite,multiAccounts');
 setDefaultEnv('GRIST_ELECTRON_AUTH', 'strict');
+setDefaultEnv('GRIST_WIDGET_LIST_URL',
+  'https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json');
 if (process.env.GRIST_ELECTRON_AUTH !== 'mixed') {
   setDefaultEnv('GRIST_FORCE_LOGIN', 'true');
 }

--- a/ext/app/electron/main.ts
+++ b/ext/app/electron/main.ts
@@ -1,4 +1,5 @@
 import * as dotenv from "dotenv";
+import {commonUrls} from 'app/common/gristUrls';
 import * as version from 'app/common/version';
 import * as log from 'app/server/lib/log';
 import * as electron from 'electron';
@@ -28,8 +29,7 @@ setDefaultEnv('GRIST_ORG_IN_PATH', 'true');
 setDefaultEnv('APP_UNTRUSTED_URL', 'http://plugins.invalid');
 setDefaultEnv('GRIST_HIDE_UI_ELEMENTS', 'helpCenter,billing,templates,multiSite,multiAccounts');
 setDefaultEnv('GRIST_ELECTRON_AUTH', 'strict');
-setDefaultEnv('GRIST_WIDGET_LIST_URL',
-  'https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json');
+setDefaultEnv('GRIST_WIDGET_LIST_URL', commonUrls.gristLabsWidgetRepository);
 if (process.env.GRIST_ELECTRON_AUTH !== 'mixed') {
   setDefaultEnv('GRIST_FORCE_LOGIN', 'true');
 }


### PR DESCRIPTION
GRIST_WIDGET_LIST_URL by default points to https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json