### PR TITLE
clean up submodule when packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Submodule cleanup fix  # See https://github.com/actions/checkout/issues/358
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
       - name: check bash
         run: yarn run check:bash:ci
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "grist-electron",
   "productName": "grist-electron",
   "description": "Grist is the evolution of spreadsheets",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "core/_build/ext/app/electron/main.js",
   "repository": "git@github.com:paulfitz/grist-electron",
   "author": "Paul Fitzpatrick <paulfitz@alum.mit.edu>",


### PR DESCRIPTION
This is not done automatically, and is important for self-hosted runners which can have left-over material from previous runs.