### PR TITLE
Use the more appropriate icon for Grist documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
       {
         "ext": "grist",
         "name": "Grist Document",
-        "role": "Editor"
+        "role": "Editor",
+        "icon": "core/static/icons/gristdoc"
       }
     ],
     "nsis": {


### PR DESCRIPTION
We have already an icon appropriate for documents. Use it in electron-builder file associations. Tested on Mac, but should work on Windows too (documentation says it's [not supported on Linux](https://www.electron.build/configuration/configuration.html#overridable-per-platform-options)). 

(Omitting the icon file extension isn't well-documented, but should result in .icns vs .ico extensions for Mac vs Windows: [source code](https://github.com/electron-userland/electron-builder/blob/47e66ca64a89395a49300e8b2da1d9baeb93825a/packages/builder-util/src/util.ts#L318), and the correct .icns extension is visible on Mac in `dist/mac-arm64/grist-electron.app/Contents/Info.plist`.)