### PR TITLE
Packaging enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
         with:
           submodules: true
 
-      - name: check bash
-        run: yarn run check:bash:ci
-
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,13 +65,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
+
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-${{ matrix.target }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.target }}-yarn-
 
       - name: Install dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn install --network-timeout 300000
       
       - name: Fix Windows x86 sqlite3 binding
-        if: startsWith(matrix.os, 'windows') && matrix.target == 'x86'
+        if: steps.yarn-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows') && matrix.target == 'x86'
         run: yarn upgrade sqlite3
         # Prebuilt binding is for x64. We must build from source for x86 target.
         # See:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -99,5 +99,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: grist-electron-${{ matrix.os }}-${{ matrix.host }}
           path: dist/grist-electron-*
           if-no-files-found: "error"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -58,17 +58,10 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
 
-      - name: check bash
-        run: yarn run check:bash:ci
-
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.host }}
-
-      - name: Add yarn
-        if: startsWith(matrix.os, 'macos')
-        run: npm install -g yarn
 
       - name: Install dependencies
         run: yarn install --network-timeout 300000

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: node_modules
+          path:
+            - node_modules
+            - core/node_modules
           key: ${{ matrix.os }}-${{ matrix.target }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.target }}-yarn-

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,10 +65,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          architecture: ${{ matrix.target }}
 
       - name: Install dependencies
         run: yarn install --network-timeout 300000
+      
+      - name: Fix Windows x86 sqlite3 binding
+        if: startsWith(matrix.os, 'windows') && matrix.target == 'x86'
+        run: yarn upgrade sqlite3
+        env:
+          npm_config_build_from_source: true
+          npm_config_target_arch: ia32
+          npm_config_fallback_to_build: true
+        
 
       - name: Hooks and crooks
         run: yarn run setup

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          architecture: ${{ matrix.host }}
+          architecture: ${{ matrix.target }}
 
       - name: Install dependencies
         run: yarn install --network-timeout 300000
@@ -86,6 +86,7 @@ jobs:
         # github endpoints hang up quite a bit, add one retry.
         run: yarn run electron:ci || yarn run electron:ci
         env:
+          TARGET_ARCH: ${{ matrix.target }}
           GITHUB_TOKEN: ${{ github.token }}
           DEBUG: electron-builder
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -96,6 +97,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-${{ matrix.host }}
+          name: ${{ matrix.os }}-${{ matrix.host }}-${{ matrix.target }}
           path: dist/grist-electron-*
           if-no-files-found: "error"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         os:
           - macos-14
-          - ubuntu-20.04
-          - windows-latest
+          - ubuntu-22.04
+          - windows-2022
         host:
           - x64
         target:
@@ -35,6 +35,10 @@ jobs:
             node: 18
             host: arm64
             target: arm64
+          - os: windows-2022
+            node: 18
+            host: x64
+            target: x86
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - name: association

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -96,3 +96,8 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/grist-electron-*
+          if-no-files-found: "error"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -41,7 +41,7 @@ jobs:
             target: x86
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
-      - name: association
+      - name: Set up bash association
         if: startsWith(matrix.os, 'windows')
         run: |
           ls
@@ -72,11 +72,14 @@ jobs:
       - name: Fix Windows x86 sqlite3 binding
         if: startsWith(matrix.os, 'windows') && matrix.target == 'x86'
         run: yarn upgrade sqlite3
+        # Prebuilt binding is for x64. We must build from source for x86 target.
+        # See:
+        # https://stackoverflow.com/questions/72553650/how-to-get-node-sqlite3-working-on-mac-m1
+        # https://yarnpkg.com/lang/en/docs/envvars/#toc-npm-config
         env:
           npm_config_build_from_source: true
           npm_config_target_arch: ia32
           npm_config_fallback_to_build: true
-        
 
       - name: Hooks and crooks
         run: yarn run setup

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,7 +38,7 @@ jobs:
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - name: association
-        if: contains(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows')
         run: |
           ls
           ls "c:\\"
@@ -67,7 +67,7 @@ jobs:
           architecture: ${{ matrix.host }}
 
       - name: Add yarn
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: startsWith(matrix.os, 'macos')
         run: npm install -g yarn
 
       - name: Install dependencies
@@ -99,6 +99,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: grist-electron-${{ matrix.os }}-${{ matrix.host }}
+          name: ${{ matrix.os }}-${{ matrix.host }}
           path: dist/grist-electron-*
           if-no-files-found: "error"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -69,9 +69,9 @@ jobs:
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path:
-            - node_modules
-            - core/node_modules
+          path: |
+            node_modules
+            core/node_modules
           key: ${{ matrix.os }}-${{ matrix.target }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ matrix.os }}-${{ matrix.target }}-yarn-

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,6 +65,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --network-timeout 300000

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,7 +67,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - uses: actions/cache@v4
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yarn-cache
         with:
           path: |
             node_modules

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and from an early standalone version of Grist developed at Grist Labs.
 
 ## Roadmap
 
- * [ ] Set up a Windows x86 build (need to resolve OOM issue)
+ * [x] Set up a Windows x86 build
  * [x] Set up a Windows x64 build
  * [x] Set up a Linux x64 build
  * [x] Set up a Mac x64 build

--- a/package.json
+++ b/package.json
@@ -42,18 +42,10 @@
     "win": {
       "target": [
         {
-          "target": "nsis",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
+          "target": "nsis"
         },
         {
-          "target": "portable",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
+          "target": "portable"
         }
       ],
       "icon": "core/static/icons/grist.ico"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "electron:linux": "electron-builder build --linux",
     "electron:ci": "electron-builder build --publish always",
     "electron": "electron-builder build --publish never",
-    "test": "cd core && rm -f junk.db && node _build/app/server/companion.js sqlite gristify junk.db && ls junk.db",
-    "check:bash:ci": "./scripts/check.sh"
+    "test": "cd core && rm -f junk.db && node _build/app/server/companion.js sqlite gristify junk.db && ls junk.db"
   },
   "resolutions": {
     "jquery": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,30 @@
     "includeSubNodeModules": true,
     "icon": "core/static/icons/grist.png",
     "win": {
-      "artifactName": "${productName}-windows-${version}-${arch}.${ext}",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ],
       "icon": "core/static/icons/grist.ico"
+    },
+    "portable": {
+      "artifactName": "${productName}-windows-portable-${version}-${arch}.${ext}"
+    },
+    "nsis": {
+      "artifactName": "${productName}-windows-installer-${version}-${arch}.${ext}",
+      "perMachine": true
     },
     "mac": {
       "artifactName": "${productName}-mac-${version}-${arch}.${ext}",
@@ -108,9 +130,6 @@
         "role": "Editor",
         "icon": "core/static/icons/gristdoc"
       }
-    ],
-    "nsis": {
-      "perMachine": true
-    }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron:preview": "electron core/_build/ext/app/electron/main.js",
     "electron:dir": "electron-builder build --linux --dir",
     "electron:linux": "electron-builder build --linux",
-    "electron:ci": "electron-builder build --publish always",
+    "electron:ci": "./scripts/ci.sh",
     "electron": "electron-builder build --publish never",
     "test": "cd core && rm -f junk.db && node _build/app/server/companion.js sqlite gristify junk.db && ls junk.db"
   },

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-echo "Bash looks good?"
-if true; then
-  echo "Bash looks good!"
-fi
-./scripts/check2.sh

--- a/scripts/check2.sh
+++ b/scripts/check2.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo "Still ok?"
-if true; then
-  echo "Still ok!"
-fi

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+case $TARGET_ARCH in
+  "x86")
+    ARCHFLAG="--ia32"
+    ;;
+  "x64")
+    ARCHFLAG="--x64"
+    ;;
+  "arm64")
+    ARCHFLAG="--arm64"
+    ;;
+  *)
+    echo "Target architecture $TARGET_ARCH not supported"
+    exit 1
+    ;;
+esac
+
+electron-builder build $ARCHFLAG --publish always

--- a/yarn.lock
+++ b/yarn.lock
@@ -2578,9 +2578,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001587:
-  version "1.0.30001618"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001618.tgz#fad74fa006aef0f01e8e5c0a5540c74d8d36ec6f"
-  integrity sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg==
+  version "1.0.30001620"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz#78bb6f35b8fe315b96b8590597094145d0b146b4"
+  integrity sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==
 
 chai-as-promised@7.1.1:
   version "7.1.1"
@@ -2890,10 +2890,10 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
-  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+commander@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.0.0.tgz#b929db6df8546080adfd004ab215ed48cf6f2592"
+  integrity sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==
 
 commander@2.9.0:
   version "2.9.0"
@@ -3590,9 +3590,9 @@ electron-publish@23.6.0:
     mime "^2.5.2"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.770"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.770.tgz#a26df8541a7fd92d938a2b42c70ba2502d0e9c62"
-  integrity sha512-ONwOsDiVvV07CMsyH4+dEaZ9L79HMH/ODHnDS3GkIhgNqdDHJN2C18kFb0fBj0RXpQywsPJl6k2Pqg1IY4r1ig==
+  version "1.4.774"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.774.tgz#1017d1758aaeeefe5423aa9d67b4b1e5d1d0a856"
+  integrity sha512-132O1XCd7zcTkzS3FgkAzKmnBuNJjK8WjcTtNuoylj7MYbqw5eXehjQ5OK91g0zm7OTKIPeaAG4CPoRfD9M1Mg==
 
 electron-updater@^5.3.0:
   version "5.3.0"
@@ -3753,9 +3753,9 @@ es-errors@^1.3.0:
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-module-lexer@^1.2.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.2.tgz#00b423304f2500ac59359cc9b6844951f372d497"
-  integrity sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.3.tgz#25969419de9c0b1fbe54279789023e8a9a788412"
+  integrity sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==
 
 es6-error@^4.1.1:
   version "4.1.1"
@@ -4187,18 +4187,7 @@ fast-fifo@^1.1.0:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
-  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
-fast-glob@^3.2.9:
+fast-glob@3.3.2, fast-glob@^3.2.9:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -4230,9 +4219,9 @@ fast-text-encoding@^1.0.0:
   integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
 
 fast-xml-parser@^4.2.2:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz#190f9d99097f0c8f2d3a0e681a10404afca052ff"
-  integrity sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz#341cc98de71e9ba9e651a67f41f1752d1441a501"
+  integrity sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==
   dependencies:
     strnum "^1.0.5"
 
@@ -7356,13 +7345,13 @@ resolve-options@^2.0.0:
     value-or-function "^4.0.0"
 
 resolve-tspaths@^0.8.3:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/resolve-tspaths/-/resolve-tspaths-0.8.18.tgz#56f686a8fc4ba1d301508a149b1516a38f7e5f17"
-  integrity sha512-68fFbsR+m8l1KLQxcUp+yd6H5QWtaORIXnC9iln5rfex5RzBTXqJ/I9Cgi6nr2fVODYI5ptcGv/CmcLCoaChVg==
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/resolve-tspaths/-/resolve-tspaths-0.8.19.tgz#f4164e657273b76d2bacb5afa5c236a2cc9fc964"
+  integrity sha512-yZkXNYyHdVytOkJLhbib7TFpaMVElk9auO9R1jDmOSXPUWEjy+V44VqX77RIQ+kf0UJIlAGRDK/yrbfwlu1UWg==
   dependencies:
     ansi-colors "4.1.3"
-    commander "11.1.0"
-    fast-glob "3.3.1"
+    commander "12.0.0"
+    fast-glob "3.3.2"
 
 resolve@^1.1.4, resolve@^1.17.0, resolve@^1.4.0, resolve@^1.9.0:
   version "1.22.8"
@@ -7517,9 +7506,9 @@ schema-utils@^3.1.1, schema-utils@^3.2.0:
     ajv-keywords "^3.5.2"
 
 selenium-webdriver@^4.20.0:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.20.0.tgz#14941ab4a59e8956a5e4b4491a8ba2bd6619d1ac"
-  integrity sha512-s/G44lGQ1xB3tmtX6NNPomlkpL6CxLdmAvp/AGWWwi4qv5Te1+qji7tPSyr6gyuoPpdYiof1rKnWe3luy0MrYA==
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.21.0.tgz#d38aebfc34770421a880afcfdb7bd8fe85ce9174"
+  integrity sha512-WaEJHZjOWNth1QG5FEpxpREER0qptZBMonFU6GtAqdCNLJVxbtC3E7oS/I/+Q1sf1W032Wg0Ebk+m46lANOXyQ==
   dependencies:
     jszip "^3.10.1"
     tmp "^0.2.3"


### PR DESCRIPTION
- Adds Windows portable build - partly addresses #27.
- Packaging pipeline now produces artifacts for inspection.
- Windows x86 build is back!
- `node_modules` is now cached, saving 3min30s of build time and an additional 2min for Windows x86 builds.
- Cleaned up workflows.